### PR TITLE
Fix: valu and debug engine literal missing

### DIFF
--- a/problem.py
+++ b/problem.py
@@ -11,7 +11,7 @@ from enum import Enum
 from typing import Any, Literal
 import random
 
-Engine = Literal["alu", "load", "store", "flow"]
+Engine = Literal["alu", "valu", "load", "store", "flow", "debug"]
 Instruction = dict[Engine, list[tuple]]
 
 


### PR DESCRIPTION
as original defined engine only has ["alu", "load", "store", "flow"]

```py
Engine = Literal["alu", "load", "store", "flow"]
```

Which should be conflict against given [example](https://github.com/anthropics/original_performance_takehome/blob/main/problem.py#L85-L87) and [ENGINE_FNS](https://github.com/anthropics/original_performance_takehome/blob/main/problem.py#L356-L362):

```py
"""
Here's an example of what an instruction might look like:

{"valu": [("*", 4, 0, 0), ("+", 8, 4, 0)], "load": [("load", 16, 17)]}
"""

ENGINE_FNS = {
    "alu": self.alu,
    "valu": self.valu,    # <-- here valu engine missing
    "load": self.load,
    "store": self.store,
    "flow": self.flow,
}
```

So I decided to add the missing "valu" and "debug" engine

```diff
-- Engine = Literal["alu", "load", "store", "flow"]
++ Engine = Literal["alu", "valu", "load", "store", "flow", "debug"]
```